### PR TITLE
-1 is not the correct value to represent NO_BUFFER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyo
 *.egg-info
+*.idea

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -18,7 +18,7 @@ from pox.lib.packet.tcp import tcp
 
 from ripl.mn import topos
 
-from riplpox.util import buildTopo, getRouting
+from util import buildTopo, getRouting
 
 log = core.getLogger()
 

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -37,6 +37,7 @@ PRIO_HYBRID_VLAN_DOWN = 900
 PRIO_HYBRID_FLOW_UP = 500
 PRIO_HYBRID_VLAN_UP = 10
 
+NO_BUFFER = 4294967295
 
 # Borrowed from pox/forwarding/l2_multi
 class Switch (EventMixin):
@@ -72,13 +73,13 @@ class Switch (EventMixin):
     msg.actions.append(of.ofp_action_output(port = outport))
     self.connection.send(msg)
 
-  def send_packet_bufid(self, outport, buffer_id = -1):
+  def send_packet_bufid(self, outport, buffer_id = NO_BUFFER):
     msg = of.ofp_packet_out(in_port=of.OFPP_NONE)
     msg.actions.append(of.ofp_action_output(port = outport))
     msg.buffer_id = buffer_id
     self.connection.send(msg)
 
-  def install(self, port, match, buf = -1, idle_timeout = 0, hard_timeout = 0,
+  def install(self, port, match, buf = NO_BUFFER, idle_timeout = 0, hard_timeout = 0,
               priority = of.OFP_DEFAULT_PRIORITY):
     msg = of.ofp_flow_mod()
     msg.match = match
@@ -89,7 +90,7 @@ class Switch (EventMixin):
     msg.buffer_id = buf
     self.connection.send(msg)
 
-  def install_multiple(self, actions, match, buf = -1, idle_timeout = 0,
+  def install_multiple(self, actions, match, buf = NO_BUFFER, idle_timeout = 0,
                        hard_timeout = 0, priority = of.OFP_DEFAULT_PRIORITY):
     msg = of.ofp_flow_mod()
     msg.match = match

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -18,7 +18,7 @@ from pox.lib.packet.tcp import tcp
 
 from ripl.mn import topos
 
-from util import buildTopo, getRouting
+from riplpox.util import buildTopo, getRouting
 
 log = core.getLogger()
 
@@ -214,13 +214,14 @@ class RipLController(EventMixin):
           ports.append(sw_port)
       # Send packet out each non-input host port
       # TODO: send one packet only.
-      for port in ports:
+        self.switches[sw].send_packet_data(outport=0xfffb)
+      #for port in ports:
         #log.info("sending to port %s on switch %s" % (port, sw))
         #buffer_id = event.ofp.buffer_id
         #if sw == dpid:
         #  self.switches[sw].send_packet_bufid(port, event.ofp.buffer_id)
         #else:
-        self.switches[sw].send_packet_data(port, event.data)
+       # self.switches[sw].send_packet_data(port, event.data)
         #  buffer_id = -1
 
   def _handle_packet_reactive(self, event):

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -214,14 +214,14 @@ class RipLController(EventMixin):
           ports.append(sw_port)
       # Send packet out each non-input host port
       # TODO: send one packet only.
-        self.switches[sw].send_packet_data(outport=0xfffb)
-      #for port in ports:
+      #  self.switches[sw].send_packet_data(outport=0xfffb)
+      for port in ports:
         #log.info("sending to port %s on switch %s" % (port, sw))
         #buffer_id = event.ofp.buffer_id
         #if sw == dpid:
         #  self.switches[sw].send_packet_bufid(port, event.ofp.buffer_id)
         #else:
-       # self.switches[sw].send_packet_data(port, event.data)
+        self.switches[sw].send_packet_data(port, event.data)
         #  buffer_id = -1
 
   def _handle_packet_reactive(self, event):


### PR DESCRIPTION
in the latest version of OpenFlow specification, the buffer_id can not be smaller than 0, the default value of -1 for buffer_id would make riplpox incompatible with the latest POX, just fix it
