### PR TITLE
Fixes for POX dart

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,7 +3,7 @@ RipL-POX (Ripcord-Lite for POX): A simple network controller for OpenFlow-based 
 == Install ==
 RipL, POX, and setuptools are the dependencies.
 
-This version has been tested with the master branch of POX, commit 0a1bbb8, made on Sat Nov 24 01:52:07 2012 -0800.
+This version has been tested with the dart branch of POX, commit 105a613, made on Fri Apr 18 16:00:55 2014 -0700.
 
 The invocation examples assume that POX available in ~/.
 
@@ -11,7 +11,7 @@ The invocation examples assume that POX available in ~/.
 cd ~/
 git clone git://github.com/noxrepo/pox
 cd pox
-git checkout 0a1bbb8
+git checkout 105a613
 
 # Build RipL:
 cd ~/

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -72,13 +72,13 @@ class Switch (object):
     msg.actions.append(of.ofp_action_output(port = outport))
     self.connection.send(msg)
 
-  def send_packet_bufid(self, outport, buffer_id = -1):
+  def send_packet_bufid(self, outport, buffer_id = None):
     msg = of.ofp_packet_out(in_port=of.OFPP_NONE)
     msg.actions.append(of.ofp_action_output(port = outport))
     msg.buffer_id = buffer_id
     self.connection.send(msg)
 
-  def install(self, port, match, buf = -1, idle_timeout = 0, hard_timeout = 0,
+  def install(self, port, match, buf = None, idle_timeout = 0, hard_timeout = 0,
               priority = of.OFP_DEFAULT_PRIORITY):
     msg = of.ofp_flow_mod()
     msg.match = match
@@ -89,7 +89,7 @@ class Switch (object):
     msg.buffer_id = buf
     self.connection.send(msg)
 
-  def install_multiple(self, actions, match, buf = -1, idle_timeout = 0,
+  def install_multiple(self, actions, match, buf = None, idle_timeout = 0,
                        hard_timeout = 0, priority = of.OFP_DEFAULT_PRIORITY):
     msg = of.ofp_flow_mod()
     msg.match = match
@@ -220,7 +220,7 @@ class RipLController(object):
         #  self.switches[sw].send_packet_bufid(port, event.ofp.buffer_id)
         #else:
         self.switches[sw].send_packet_data(port, event.data)
-        #  buffer_id = -1
+        #  buffer_id = None
 
   def _handle_packet_reactive(self, event):
     packet = event.parsed

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -248,7 +248,7 @@ class RipLController(object):
   def _handle_packet_proactive(self, event):
     packet = event.parse()
 
-    if packet.dst.isMulticast():
+    if packet.dst.is_multicast:
       self._flood(event)
     else:
       hosts = self._raw_dpids(self.t.layer_nodes(self.t.LAYER_HOST))

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -159,13 +159,16 @@ class RipLController(object):
       self.switches[node_dpid].install(out_port, match, idle_timeout =
                                        IDLE_TIMEOUT)
 
+  def _eth_to_int(self, eth):
+    return sum(([ord(x)*2**((5-i)*8) for i,x in enumerate(eth.raw)]))
+
   def _src_dst_hash(self, src_dpid, dst_dpid):
     "Return a hash based on src and dst dpids."
     return crc32(pack('QQ', src_dpid, dst_dpid))
 
   def _install_proactive_path(self, src, dst):
     """Install entries on route between two hosts based on MAC addrs.
-    
+
     src and dst are unsigned ints.
     """
     src_sw = self.t.up_nodes(self.t.id_gen(dpid = src).name_str())
@@ -252,9 +255,9 @@ class RipLController(object):
       self._flood(event)
     else:
       hosts = self._raw_dpids(self.t.layer_nodes(self.t.LAYER_HOST))
-      if packet.src.toInt() not in hosts:
+      if self._eth_to_int(packet.src) not in hosts:
         raise Exception("unrecognized src: %s" % packet.src)
-      if packet.dst.toInt() not in hosts:
+      if self._eth_to_int(packet.dst) not in hosts:
         raise Exception("unrecognized dst: %s" % packet.dst)
       raise Exception("known host MACs but entries weren't pushed down?!?")
 

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -504,7 +504,11 @@ class RipLController(EventMixin):
 
 def launch(topo = None, routing = None, mode = None):
   """
-  Args in format toponame,arg1,arg2,...
+  Launch RipL-POX
+
+  topo is in format toponame,arg1,arg2,...
+  routing is a routing type (e.g., st, random, hashed)
+  mode is a controller mode (e.g., proactive, reactive, hybrid)
   """
   if not mode:
     mode = DEF_MODE

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -39,7 +39,7 @@ PRIO_HYBRID_VLAN_UP = 10
 
 
 # Borrowed from pox/forwarding/l2_multi
-class Switch (EventMixin):
+class Switch (object):
   def __init__ (self):
     self.connection = None
     self.ports = None
@@ -65,7 +65,7 @@ class Switch (EventMixin):
     self.disconnect()
     log.debug("Connect %s" % (connection,))
     self.connection = connection
-    self._listeners = self.listenTo(connection)
+    self._listeners = connection.addListeners(self)
 
   def send_packet_data(self, outport, data = None):
     msg = of.ofp_packet_out(in_port=of.OFPP_NONE, data = data)
@@ -109,7 +109,7 @@ class Switch (EventMixin):
 def sep():
   log.info("************************************************")
 
-class RipLController(EventMixin):
+class RipLController(object):
 
   def __init__ (self, t, r, mode):
     self.switches = {}  # Switches seen: [dpid] -> Switch
@@ -120,7 +120,7 @@ class RipLController(EventMixin):
 
     # TODO: generalize all_switches_up to a more general state machine.
     self.all_switches_up = False  # Sequences event handling.
-    self.listenTo(core.openflow, priority=0)
+    core.openflow.addListeners(self, priority=0)
 
   def _raw_dpids(self, arr):
     "Convert a list of name strings (from Topo object) to numbers."

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -266,9 +266,9 @@ class RipLController(object):
   def _install_hybrid_dynamic_flows(self, event, out_dpid, final_out_port, packet):
     "Install entry at ingress switch."
     in_name = self.t.id_gen(dpid = event.dpid).name_str()
-    #log.info("in_name: %s" % in_name) 
+    #log.info("in_name: %s" % in_name)
     out_name = self.t.id_gen(dpid = out_dpid).name_str()
-    #log.info("out_name: %s" % out_name) 
+    #log.info("out_name: %s" % out_name)
     hash_ = self._ecmp_hash(packet)
     src_dst_route = self.r.get_route(in_name, out_name, hash_)
     # Choose a random core switch.
@@ -277,7 +277,7 @@ class RipLController(object):
     core_sw_id = self.t.id_gen(dpid = core_sw)
     core_sw_name = self.t.id_gen(dpid = core_sw).name_str()
 
-    route = self.r.get_route(in_name, core_sw_name, None)    
+    route = self.r.get_route(in_name, core_sw_name, None)
     assert len(route) == 3
     log.info("route: %s" % route)
 
@@ -288,10 +288,10 @@ class RipLController(object):
     #log.info("core_sw_index: %s" % core_sw_index)
 
     dst_host_index = self.dpid_port_to_host_index(out_dpid, final_out_port)
-    #log.info("dst_host_index: %s" % dst_host_index) 
+    #log.info("dst_host_index: %s" % dst_host_index)
 
     vlan = (dst_host_index << 2) + core_sw_index
-    log.info("vlan: %s" % vlan) 
+    log.info("vlan: %s" % vlan)
     log.info("len(src_dst_route): %i" % len(src_dst_route))
 
     if len(src_dst_route) == 1:
@@ -300,7 +300,7 @@ class RipLController(object):
                (match.dl_src, match.dl_dst, in_name))
       self.switches[event.dpid].install(final_out_port, match, idle_timeout =
                                      HYBRID_IDLE_TIMEOUT,
-                                     priority = PRIO_HYBRID_FLOW_DOWN)      
+                                     priority = PRIO_HYBRID_FLOW_DOWN)
     else:
       # Write VLAN and send up
       src_port, dst_port = self.t.port(route[0], route[1])
@@ -325,7 +325,7 @@ class RipLController(object):
     # Insert flow, deliver packet directly to destination.
     if packet.dst in self.macTable:
       out_dpid, out_port = self.macTable[packet.dst]
-      log.info("found %s on dpid %s, port %s" % (packet.dst, out_dpid, out_port))      
+      log.info("found %s on dpid %s, port %s" % (packet.dst, out_dpid, out_port))
       self._install_hybrid_dynamic_flows(event, out_dpid, out_port, packet)
 
       #log.info("sending to entry in mactable: %s %s" % (out_dpid, out_port))
@@ -441,7 +441,7 @@ class RipLController(object):
 #          edge_port, agg_port = self.t.port(edge_sw_name, agg_sw_name)
 #          log.info("adding entry from %s to %s via VLAN %i and port %i" %
 #                   (edge_sw_name, agg_sw_name, match.dl_vlan, edge_port))
-#          self.switches[edge_sw].install(edge_port, match, 
+#          self.switches[edge_sw].install(edge_port, match,
 #                                         priority = PRIO_HYBRID_VLAN_UP)
 
     # Add one flow entry for each agg switch pointing up
@@ -456,15 +456,15 @@ class RipLController(object):
         if agg_sw_name in self.t.g[core_sw_name]:
             # If connected, add entry.
             agg_port, core_port = self.t.port(agg_sw_name, core_sw_name)
-            
+
             # Form OF match
             match = of.ofp_match()
             # Highest-order four bits are host index
-    
+
             # Lowest-order two bits are core switch ID
             core_sw_id = self.t.id_gen(dpid = core_sw)
             core_index = (core_sw_id.sw - 1) * 2 + (core_sw_id.host - 1)
-    
+
             for host_index in range((self.t.k ** 3) / 4):
               match.dl_vlan = (host_index << 2) + core_index
               #log.info("vlan: %s" % match.dl_vlan)
@@ -473,7 +473,7 @@ class RipLController(object):
                        (agg_sw_name, core_sw_name, match.dl_vlan, agg_port))
               self.switches[agg_sw].install(agg_port, match,
                                              priority = PRIO_HYBRID_VLAN_UP)
-      
+
 
   def _handle_ConnectionUp (self, event):
     sw = self.switches.get(event.dpid)

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -162,6 +162,9 @@ class RipLController(object):
   def _eth_to_int(self, eth):
     return sum(([ord(x)*2**((5-i)*8) for i,x in enumerate(eth.raw)]))
 
+  def _int_to_eth(self, inteth):
+    return EthAddr("%012x" % (inteth,))
+
   def _src_dst_hash(self, src_dpid, dst_dpid):
     "Return a hash based on src and dst dpids."
     return crc32(pack('QQ', src_dpid, dst_dpid))
@@ -183,8 +186,8 @@ class RipLController(object):
 
     # Form OF match
     match = of.ofp_match()
-    match.dl_src = EthAddr(src)
-    match.dl_dst = EthAddr(dst)
+    match.dl_src = self._int_to_eth(src)
+    match.dl_dst = self._int_to_eth(dst)
 
     dst_host_name = self.t.id_gen(dpid = dst).name_str()
     final_out_port, ignore = self.t.port(route[-1], dst_host_name)

--- a/riplpox/riplpox.py
+++ b/riplpox/riplpox.py
@@ -180,8 +180,8 @@ class RipLController(object):
 
     # Form OF match
     match = of.ofp_match()
-    match.dl_src = EthAddr(src).toRaw()
-    match.dl_dst = EthAddr(dst).toRaw()
+    match.dl_src = EthAddr(src)
+    match.dl_dst = EthAddr(dst)
 
     dst_host_name = self.t.id_gen(dpid = dst).name_str()
     final_out_port, ignore = self.t.port(route[-1], dst_host_name)


### PR DESCRIPTION
I'm not sure if you care anymore, Brandon, but this is a quick pass at getting riplpox working on recent versions of POX.  A quick test indicates that the POX/riplpox part seems to work now, though it appears there are incompatibilities with current versions of Mininet.  And, for that matter, with the cs244 branch?

With current Mininet, proactive didn't work.  I didn't look into this very far and instead tried the cs244 branch.

With the cs244 branch, I had to tweak some function names (addSwitch vs. add_switch, etc.) to get ripl to start, but then proactive mode seemed to work.
